### PR TITLE
update slack readme to include space between doc link and text

### DIFF
--- a/integrations/productivity-tools/slack-connection/README.md
+++ b/integrations/productivity-tools/slack-connection/README.md
@@ -4,7 +4,7 @@ description: Seamlessly integrate Secoda with your Slack workspace
 
 # Slack
 
-Connecting your workspace to Slack allows you to receive notifications from Secoda regarding changes in your workspace and ask questions about your data directly from Slack. When using the Secoda integration for Slack you're agreeing to our [privacy-policy.md](../../../policies/privacy-policy.md "mention")and [terms-of-use.md](../../../policies/terms-of-use.md "mention").
+Connecting your workspace to Slack allows you to receive notifications from Secoda regarding changes in your workspace and ask questions about your data directly from Slack. When using the Secoda integration for Slack you're agreeing to our [privacy-policy.md](../../../policies/privacy-policy.md "mention") and [terms-of-use.md](../../../policies/terms-of-use.md "mention").
 
 You can learn more about all of the capabilities of this integration here: [slack-user-guide.md](slack-user-guide.md "mention")
 


### PR DESCRIPTION
Adds space between privacy policy link and the following text:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/6a171812-7305-4642-abbb-e575889ebc0d" />